### PR TITLE
Timestamp to NSDate mapping added

### DIFF
--- a/EasyMapping/EKMappingTimestampFormats.h
+++ b/EasyMapping/EKMappingTimestampFormats.h
@@ -1,0 +1,18 @@
+//
+//  EKMappingTimestampFormats.h
+//  EasyMappingExample
+//
+//  Created by Sergii Kryvoblotskyi on 1/15/15.
+//  Copyright (c) 2015 EasyKit. All rights reserved.
+//
+
+typedef NS_ENUM(NSInteger, EKTimestampFormat){
+    /**
+     *  Represents "seconds" format. Like 1421333849 for 01/15/2015 16:57:29
+     */
+    EKTimestampFormatSeconds,
+    /**
+     *  Represents "milliseconds" format. Like 1421333849000 for 01/15/2015 16:57:29
+     */
+    EKTimestampFormatMilliseconds
+};

--- a/EasyMapping/EKObjectMapping.h
+++ b/EasyMapping/EKObjectMapping.h
@@ -23,6 +23,17 @@
 
 #import "EKMappingBlocks.h"
 
+typedef NS_ENUM(NSInteger, EKTimestampFormat){
+    /**
+     *  Represents "seconds" format. Like 1421333849 for 01/15/2015 16:57:29
+     */
+    EKTimestampFormatSeconds,
+    /**
+     *  Represents "milliseconds" format. Like 1421333849000 for 01/15/2015 16:57:29
+     */
+    EKTimestampFormatMilliseconds
+};
+
 @protocol EKMappingProtocol;
 
 /**
@@ -128,8 +139,10 @@
  @param keyPath JSON keypath, that will be used by valueForKeyPath: method
  
  @param property Property name.
+ 
+ @param timestamp format. (Accepts EKTimestampFormatSeconds or EKTimestampFormatMilliseconds)
  */
-- (void)mapTimestampWithKeyPath:(NSString *)keyPath toDateProperty:(NSString *)property;
+- (void)mapKeyPath:(NSString *)keyPath toProperty:(NSString *)property withTimestampFormat:(EKTimestampFormat)timestampFormat;
 
 /**
  Maps properties from array. We assume, that names of keypaths and properties are the same.

--- a/EasyMapping/EKObjectMapping.h
+++ b/EasyMapping/EKObjectMapping.h
@@ -22,17 +22,7 @@
 // THE SOFTWARE.
 
 #import "EKMappingBlocks.h"
-
-typedef NS_ENUM(NSInteger, EKTimestampFormat){
-    /**
-     *  Represents "seconds" format. Like 1421333849 for 01/15/2015 16:57:29
-     */
-    EKTimestampFormatSeconds,
-    /**
-     *  Represents "milliseconds" format. Like 1421333849000 for 01/15/2015 16:57:29
-     */
-    EKTimestampFormatMilliseconds
-};
+#import "EKMappingTimestampFormats.h"
 
 @protocol EKMappingProtocol;
 

--- a/EasyMapping/EKObjectMapping.h
+++ b/EasyMapping/EKObjectMapping.h
@@ -123,6 +123,15 @@
 - (void)mapKeyPath:(NSString *)keyPath toProperty:(NSString *)property withDateFormat:(NSString *)dateFormat;
 
 /**
+ Map JSON keyPath that represents timestamp (seconds since 1970-01-01T00:00:01+00:00) to NSDate property. This method assumes value contains NSSNumber or NSString
+ 
+ @param keyPath JSON keypath, that will be used by valueForKeyPath: method
+ 
+ @param property Property name.
+ */
+- (void)mapTimestampWithKeyPath:(NSString *)keyPath toDateProperty:(NSString *)property;
+
+/**
  Maps properties from array. We assume, that names of keypaths and properties are the same.
  
  @param propertyNamesArray Array of property names

--- a/EasyMapping/EKObjectMapping.m
+++ b/EasyMapping/EKObjectMapping.m
@@ -96,7 +96,7 @@
     }];
 }
 
-- (void)mapTimestampWithKeyPath:(NSString *)keyPath toDateProperty:(NSString *)property
+- (void)mapKeyPath:(NSString *)keyPath toProperty:(NSString *)property withTimestampFormat:(EKTimestampFormat)timestampFormat
 {
     NSParameterAssert(keyPath);
     NSParameterAssert(property);
@@ -104,9 +104,27 @@
     [self mapKeyPath:keyPath
           toProperty:property
       withValueBlock:^id(NSString * key, id value) {
-          return [value respondsToSelector:@selector(doubleValue)] ? [NSDate dateWithTimeIntervalSince1970:[value doubleValue]] : nil;
+          
+          if ([value respondsToSelector:@selector(doubleValue)]) {
+              
+              NSTimeInterval doubleValue = [value doubleValue];
+              if (timestampFormat == EKTimestampFormatMilliseconds) {
+                  doubleValue /= 1000.0;
+              }
+          }
+          return nil;
+          
       } reverseBlock:^id(id value) {
-          return [value isKindOfClass:[NSDate class]] ? @([value timeIntervalSince1970]) : nil;
+          
+          if ([value isKindOfClass:[NSDate class]]) {
+              
+              NSTimeInterval timeInterval = [value timeIntervalSince1970];
+              if (timestampFormat == EKTimestampFormatMilliseconds) {
+                  timeInterval *= 1000.0;
+              }
+              return @(timeInterval);
+          }
+          return nil;
       }];
 }
 

--- a/EasyMapping/EKObjectMapping.m
+++ b/EasyMapping/EKObjectMapping.m
@@ -104,28 +104,10 @@
     [self mapKeyPath:keyPath
           toProperty:property
       withValueBlock:^id(NSString * key, id value) {
-          
-          if ([value respondsToSelector:@selector(doubleValue)]) {
-              
-              NSTimeInterval doubleValue = [value doubleValue];
-              if (timestampFormat == EKTimestampFormatMilliseconds) {
-                  doubleValue /= 1000.0;
-              }
-          }
-          return nil;
-          
+          return [value respondsToSelector:@selector(doubleValue)] ? [EKTransformer transformValue:value withTimestampFormat:timestampFormat] : nil;
       } reverseBlock:^id(id value) {
-          
-          if ([value isKindOfClass:[NSDate class]]) {
-              
-              NSTimeInterval timeInterval = [value timeIntervalSince1970];
-              if (timestampFormat == EKTimestampFormatMilliseconds) {
-                  timeInterval *= 1000.0;
-              }
-              return @(timeInterval);
-          }
-          return nil;
-      }];
+          return [value isKindOfClass:[NSDate class]] ? [EKTransformer transformDate:value withTimestampFormat:timestampFormat] : nil;
+    }];
 }
 
 - (void)mapPropertiesFromArray:(NSArray *)propertyNamesArray

--- a/EasyMapping/EKObjectMapping.m
+++ b/EasyMapping/EKObjectMapping.m
@@ -96,6 +96,20 @@
     }];
 }
 
+- (void)mapTimestampWithKeyPath:(NSString *)keyPath toDateProperty:(NSString *)property
+{
+    NSParameterAssert(keyPath);
+    NSParameterAssert(property);
+    
+    [self mapKeyPath:keyPath
+          toProperty:property
+      withValueBlock:^id(NSString * key, id value) {
+          return [value respondsToSelector:@selector(doubleValue)] ? [NSDate dateWithTimeIntervalSince1970:[value doubleValue]] : nil;
+      } reverseBlock:^id(id value) {
+          return [value isKindOfClass:[NSDate class]] ? @([value timeIntervalSince1970]) : nil;
+      }];
+}
+
 - (void)mapPropertiesFromArray:(NSArray *)propertyNamesArray
 {
     NSParameterAssert([propertyNamesArray isKindOfClass:[NSArray class]]);

--- a/EasyMapping/EKTransformer.h
+++ b/EasyMapping/EKTransformer.h
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import "EKMappingTimestampFormats.h"
 
 extern NSString * const EKRailsDefaultDatetimeFormat;
 extern NSString * const EKBrazilianDefaultDateFormat;
@@ -53,5 +54,28 @@ extern NSString * const EKBrazilianDefaultDateFormat;
  @result NSString object.
  */
 + (NSString *)transformDate:(NSDate *)dateToBeTransformed withDateFormat:(NSString *)dateFormat;
+
+/**
+ Transform NSNumber/NSString into date.
+ 
+ @param value NSNumber or NSString
+ 
+ @param timestampFormat EKTimestampFormat. Accepts EKTimestampFormatSeconds or EKTimestampFormatMilliseconds
+ 
+ @result NSDate object.
+ */
++ (NSDate *)transformValue:(id)value withTimestampFormat:(EKTimestampFormat)timestampFormat;
+
+/**
+ Transform date into number.
+ 
+ @param dateToBeTransformed Date to transform.
+ 
+ @param timestampFormat EKTimestampFormat. Accepts EKTimestampFormatSeconds or EKTimestampFormatMilliseconds
+ 
+ @result NSNumber object.
+ */
++ (NSNumber *)transformDate:(NSDate *)dateToBeTransformted withTimestampFormat:(EKTimestampFormat)timestampFormat;
+
 
 @end

--- a/EasyMapping/EKTransformer.m
+++ b/EasyMapping/EKTransformer.m
@@ -30,6 +30,8 @@ NSString * const kDateFormatterKey = @"SCDateFormatter";
 
 @implementation EKTransformer
 
+#pragma mark - Date/String
+
 + (NSDate *)transformString:(NSString *)stringToBeTransformed withDateFormat:(NSString *)dateFormat
 {
     NSDateFormatter *format = [self dateFormatter];
@@ -55,6 +57,26 @@ NSString * const kDateFormatterKey = @"SCDateFormatter";
         [dictionary setObject:dateFormatter forKey:kDateFormatterKey];
     }
     return dateFormatter;
+}
+
+#pragma mark - Date/NSTimeInterval
+
++ (NSDate *)transformValue:(id)value withTimestampFormat:(EKTimestampFormat)timestampFormat
+{
+    NSTimeInterval doubleValue = [value doubleValue];
+    if (timestampFormat == EKTimestampFormatMilliseconds) {
+        doubleValue /= 1000.0;
+    }
+    return [NSDate dateWithTimeIntervalSince1970:doubleValue];
+}
+
++ (NSNumber *)transformDate:(NSDate *)dateToBeTransformted withTimestampFormat:(EKTimestampFormat)timestampFormat
+{
+    NSTimeInterval timeInterval = [dateToBeTransformted timeIntervalSince1970];
+    if (timestampFormat == EKTimestampFormatMilliseconds) {
+        timeInterval *= 1000.0;
+    }
+    return @(timeInterval);
 }
 
 @end

--- a/EasyMappingExample/EasyMappingExample.xcodeproj/project.pbxproj
+++ b/EasyMappingExample/EasyMappingExample.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 		9AE54FE6190BD9B5003A3B56 /* EasyMappingExample.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = EasyMappingExample.xcdatamodel; sourceTree = "<group>"; };
 		9E9BD3814FE20F5C7E01D5C1 /* Pods-MacOS Benchmark.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacOS Benchmark.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MacOS Benchmark/Pods-MacOS Benchmark.debug.xcconfig"; sourceTree = "<group>"; };
 		A7E98E6E1DB90FE1A193665A /* Pods-iOS Benchmark.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Benchmark.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS Benchmark/Pods-iOS Benchmark.release.xcconfig"; sourceTree = "<group>"; };
+		A7F3CE741A6814FC004AECCE /* EKMappingTimestampFormats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EKMappingTimestampFormats.h; sourceTree = "<group>"; };
 		A9D16CF616F2B2770003759B /* EasyMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EasyMapping.h; sourceTree = "<group>"; };
 		A9D16CF716F2B2770003759B /* EKPropertyMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EKPropertyMapping.h; sourceTree = "<group>"; };
 		A9D16CF816F2B2770003759B /* EKPropertyMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EKPropertyMapping.m; sourceTree = "<group>"; };
@@ -873,6 +874,7 @@
 				9A8420ED19571AD4006DDDE3 /* Helpers */,
 				9A8420EC19571AC6006DDDE3 /* Convenience */,
 				A9D16CF616F2B2770003759B /* EasyMapping.h */,
+				A7F3CE741A6814FC004AECCE /* EKMappingTimestampFormats.h */,
 				A9D16CFB16F2B2770003759B /* EKMappingBlocks.h */,
 				9A20569E1956CF7900499FC3 /* EKMappingProtocol.h */,
 			);


### PR DESCRIPTION
I'm not sure about method naming, but I found this feature very useful, because a lot of REST APIs use unix timestamps as date transferring format.