### PR TITLE
Some refactoring of non-nested one-mapping

### DIFF
--- a/EasyMapping/EKObjectMapping.h
+++ b/EasyMapping/EKObjectMapping.h
@@ -210,7 +210,6 @@
  @warning If you have recursive mappings, do not use this method, cause it can cause infinite recursion to happen. Or you need to handle recursive mappings situation by yourself, subclassing EKObjectMapping and providing different mappings for different mapping levels.
  */
 - (void)           hasOne:(Class)objectClass
-forDictionaryFromKeyPaths:(NSArray *)keyPaths
               forProperty:(NSString *)property
         withObjectMapping:(EKObjectMapping *)objectMapping;
 

--- a/EasyMapping/EKObjectMapping.m
+++ b/EasyMapping/EKObjectMapping.m
@@ -201,22 +201,20 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     [self.hasOneMappings setObject:relationship forKey:keyPath];
 }
 
--(void)hasOne:(Class)objectClass forDictionaryFromKeyPaths:(NSArray *)keyPaths forProperty:(NSString *)property withObjectMapping:(EKObjectMapping *)mapping
+-(void)hasOne:(Class)objectClass forProperty:(NSString *)property withObjectMapping:(EKObjectMapping *)mapping
 {
     if (!mapping) {
         NSParameterAssert([objectClass conformsToProtocol:@protocol(EKMappingProtocol)] ||
                           [objectClass conformsToProtocol:@protocol(EKManagedMappingProtocol)]);
     }
-    NSParameterAssert(keyPaths);
     NSParameterAssert(property);
     
     EKRelationshipMapping * relationship = [EKRelationshipMapping new];
     relationship.objectClass = objectClass;
-    relationship.nonNestedKeyPaths = keyPaths;
     relationship.property = property;
     relationship.objectMapping = mapping;
-    
-    self.hasOneMappings[keyPaths.firstObject] = relationship;
+    NSString *keyPath = [NSString stringWithFormat:@"self.%@", property];
+    [self.hasOneMappings setObject:relationship forKey:keyPath];
 }
 
 -(void)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath

--- a/EasyMapping/EKRelationshipMapping.h
+++ b/EasyMapping/EKRelationshipMapping.h
@@ -19,8 +19,6 @@
 
 @property (nonatomic, strong) EKObjectMapping *objectMapping;
 
-@property (nonatomic, strong) NSArray * nonNestedKeyPaths;
-
 - (NSDictionary *)extractObjectFromRepresentation:(NSDictionary *)representation;
 
 @end

--- a/EasyMapping/EKRelationshipMapping.m
+++ b/EasyMapping/EKRelationshipMapping.m
@@ -17,22 +17,17 @@
 
 -(NSDictionary *)extractObjectFromRepresentation:(NSDictionary *)representation
 {
-    if (self.nonNestedKeyPaths == nil)
-    {
+    if (self.keyPath) {
         return [representation valueForKeyPath:self.keyPath];
     }
     else {
-        NSMutableDictionary * values = [NSMutableDictionary dictionaryWithCapacity:self.nonNestedKeyPaths.count];
-        
-        for (NSString * keyPath in self.nonNestedKeyPaths)
-        {
-            id value = [representation valueForKeyPath:keyPath];
-            if (value && value!=(id)[NSNull null])
-            {
-                values[keyPath] = value;
-            }
-        }
-        return [values copy];
+        EKObjectMapping *mapping = [self objectMapping];
+        NSMutableSet *keys = [NSMutableSet new];
+        [keys addObjectsFromArray:mapping.propertyMappings.allKeys];
+        [keys addObjectsFromArray:mapping.hasOneMappings.allKeys];
+        [keys addObjectsFromArray:mapping.hasManyMappings.allKeys];
+        NSDictionary *value = [representation dictionaryWithValuesForKeys:keys.allObjects];
+        return value;
     }
 }
 

--- a/EasyMapping/EKSerializer.m
+++ b/EasyMapping/EKSerializer.m
@@ -43,15 +43,15 @@
             NSDictionary *hasOneRepresentation = [self serializeObject:hasOneObject
                                                            withMapping:[mapping objectMapping]];
             
-            if (mapping.nonNestedKeyPaths)
+            if (mapping.keyPath)
             {
+                [representation setObject:hasOneRepresentation forKey:mapping.keyPath];
+            }
+            else {
                 for (NSString * key in hasOneRepresentation.allKeys)
                 {
                     representation[key]=hasOneRepresentation[key];
                 }
-            }
-            else {
-                [representation setObject:hasOneRepresentation forKey:mapping.keyPath];
             }
         }
     }];
@@ -101,15 +101,15 @@
                                                            withMapping:(EKManagedObjectMapping *)[mapping objectMapping]
                                                            fromContext:context];
             
-            if (mapping.nonNestedKeyPaths)
+            if (mapping.keyPath)
             {
+                [representation setObject:hasOneRepresentation forKey:mapping.keyPath];
+            }
+            else {
                 for (NSString * key in hasOneRepresentation.allKeys)
                 {
                     representation[key]=hasOneRepresentation[key];
                 }
-            }
-            else {
-                [representation setObject:hasOneRepresentation forKey:mapping.keyPath];
             }
         }
     }];

--- a/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
+++ b/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
@@ -89,8 +89,7 @@
             ^(EKManagedObjectMapping *mapping) {
       [mapping mapPropertiesFromArray:@[@"name", @"email", @"gender"]];
       
-      [mapping hasOne:[ManagedCar class] forDictionaryFromKeyPaths:@[@"carId",@"carModel",@"carYear"]
-          forProperty:@"car" withObjectMapping:[self carNonNestedMapping]];
+      [mapping hasOne:[ManagedCar class] forProperty:@"car" withObjectMapping:[self carNonNestedMapping]];
                 mapping.primaryKey = @"personID";
     }];
 }

--- a/EasyMappingExample/Classes/Providers/MappingProvider.m
+++ b/EasyMappingExample/Classes/Providers/MappingProvider.m
@@ -89,8 +89,7 @@
             return [genders allKeysForObject:value].lastObject;
         }];
         
-        [mapping hasOne:[Car class] forDictionaryFromKeyPaths:@[@"carId",@"carModel",@"carYear"]
-            forProperty:@"car" withObjectMapping:[self carNonNestedMapping]];
+        [mapping hasOne:[Car class] forProperty:@"car" withObjectMapping:[self carNonNestedMapping]];
   }];
 }
 


### PR DESCRIPTION
This feature is really very handy, but do we really need explicit keys declaration when defining such kind of relationship mapping? Are there any cases when we should pass as a "keyPaths" param any other keys than keys used in relationship mapping? So why not just use them?
Also using current design force us to define the same keys in two separate places which can be not so handy. I've used "self." + property to store this mapping to avoid possible collisions.
I believe these changes does not break anything, at least tests.
Am I missing something here?
