### PR TITLE
XCTestCase category methods to test mapping and serialization

### DIFF
--- a/EasyMapping/XCTestCase+EasyMapping.h
+++ b/EasyMapping/XCTestCase+EasyMapping.h
@@ -1,0 +1,33 @@
+//
+//  XCTestCase+EasyMapping.h
+//  EasyMappingExample
+//
+//  Created by Ilya Puchka on 14.01.15.
+//  Copyright (c) 2015 EasyKit. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@class EKObjectMapping;
+
+@interface XCTestCase (EasyMapping)
+
+- (id)    testMapping:(EKObjectMapping *)mapping
+   withRepresentation:(NSDictionary *)representation
+       expectedObject:(id)expectedObject;
+
+- (id)    testMapping:(EKObjectMapping *)mapping
+   withRepresentation:(NSDictionary *)representation
+       expectedObject:(id)expectedObject
+     skippingKeyPaths:(NSArray *)keyPathsToSkip;
+
+- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping
+                                     withObject:(id)object
+                         expectedRepresentation:(NSDictionary *)expectedRepresentation;
+
+- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping
+                                     withObject:(id)object
+                         expectedRepresentation:(NSDictionary *)expectedRepresentation
+                               skippingKeyPaths:(NSArray *)keyPathsToSkip;
+
+@end

--- a/EasyMapping/XCTestCase+EasyMapping.h
+++ b/EasyMapping/XCTestCase+EasyMapping.h
@@ -12,22 +12,23 @@
 
 @interface XCTestCase (EasyMapping)
 
-- (id)    testMapping:(EKObjectMapping *)mapping
-   withRepresentation:(NSDictionary *)representation
-       expectedObject:(id)expectedObject;
+- (id)testObjectFromExternalRepresentation:(NSDictionary *)externalRepresentation
+                               withMapping:(EKObjectMapping *)mapping
+                            expectedObject:(id)expectedObject;
 
-- (id)    testMapping:(EKObjectMapping *)mapping
-   withRepresentation:(NSDictionary *)representation
-       expectedObject:(id)expectedObject
-     skippingKeyPaths:(NSArray *)keyPathsToSkip;
+- (id)testObjectFromExternalRepresentation:(NSDictionary *)externalRepresentation
+                               withMapping:(EKObjectMapping *)mapping
+                            expectedObject:(id)expectedObject
+                          skippingKeyPaths:(NSArray *)keyPathsToSkip;
 
-- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping
-                                     withObject:(id)object
-                         expectedRepresentation:(NSDictionary *)expectedRepresentation;
+- (NSDictionary *)testSerializeObject:(id)object
+                          withMapping:(EKObjectMapping *)mapping
+               expectedRepresentation:(NSDictionary *)expectedRepresentation;
 
-- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping
-                                     withObject:(id)object
-                         expectedRepresentation:(NSDictionary *)expectedRepresentation
-                               skippingKeyPaths:(NSArray *)keyPathsToSkip;
+- (NSDictionary *)testSerializeObject:(id)object
+                          withMapping:(EKObjectMapping *)mapping
+               expectedRepresentation:(NSDictionary *)expectedRepresentation
+                     skippingKeyPaths:(NSArray *)keyPathsToSkip;
+
 
 @end

--- a/EasyMapping/XCTestCase+EasyMapping.m
+++ b/EasyMapping/XCTestCase+EasyMapping.m
@@ -36,8 +36,8 @@
         }
         id mappedValue = [mappedObject valueForKeyPath:keyPath];
         id expectedValue = [expectedObject valueForKeyPath:keyPath];
-        NSString *keyPathString = [self keyPathByAppedingKeyPath:keyPath
-                                                   toRootKeyPath:rootKeyPath];
+        NSString *keyPathString = [self keyPathByAppendingKeyPath:keyPath
+                                                    toRootKeyPath:rootKeyPath];
         XCTAssertEqualObjects(mappedValue, expectedValue, "Mapping failed on keypath %@. Expected value is - %@, value after mapping is - %@", keyPathString, expectedValue, mappedValue);
     }
     
@@ -49,8 +49,8 @@
         id relationshipObject = [mappedObject valueForKeyPath:keyPath];
         id expectedRelationshipObject = [expectedObject valueForKeyPath:keyPath];
         NSArray *relationshipKeyPathsToSkip = [self extractRelationshipKeyPathsFromKeyPaths:keyPathsToSkip forRelationship:keyPath];
-        NSString *relationshipRootKeyPath = [self keyPathByAppedingKeyPath:keyPath
-                                                             toRootKeyPath:rootKeyPath];
+        NSString *relationshipRootKeyPath = [self keyPathByAppendingKeyPath:keyPath
+                                                              toRootKeyPath:rootKeyPath];
         [self testMapping:hasOneMapping.objectMapping withMappedObject:relationshipObject expectedObject:expectedRelationshipObject skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
     }
     
@@ -65,19 +65,10 @@
         [relationshipObjects enumerateObjectsUsingBlock:^(id relationshipObject, NSUInteger idx, BOOL *stop) {
             id expectedRelationshipObject = expectedRelationshipObjects[idx];
             NSString *indexKeyPath = [NSString stringWithFormat:@"%@[%lu]", keyPath, idx];
-            NSString *relationshipRootKeyPath = [self keyPathByAppedingKeyPath:indexKeyPath
-                                                                 toRootKeyPath:rootKeyPath];
+            NSString *relationshipRootKeyPath = [self keyPathByAppendingKeyPath:indexKeyPath
+                                                                  toRootKeyPath:rootKeyPath];
             [self testMapping:hasManyMapping.objectMapping withMappedObject:relationshipObject expectedObject:expectedRelationshipObject skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
         }];
-    }
-}
-
-- (void)testPropertiesWithMapping:(EKObjectMapping *)mapping withMappedObject:(id)mappedObject expectedObject:(id)expectedObject keypathsToCheck:(NSArray *)keyPathsToCheck
-{
-    for (NSString *keyPath in keyPathsToCheck) {
-        id mappedValue = [mappedObject valueForKeyPath:keyPath];
-        id expectedValue = [expectedObject valueForKeyPath:keyPath];
-        XCTAssertEqualObjects(mappedValue, expectedValue, "Mapping failed on keypath %@. Expected value is - %@, value after mapping is - %@", keyPath, expectedValue, mappedValue);
     }
 }
 
@@ -135,10 +126,13 @@
     return [mKeyPaths copy];
 }
 
-- (NSString *)keyPathByAppedingKeyPath:(NSString *)keyPath toRootKeyPath:(NSString *)rootKeyPath
+- (NSString *)keyPathByAppendingKeyPath:(NSString *)keyPath toRootKeyPath:(NSString *)rootKeyPath
 {
     if (!rootKeyPath) {
         return keyPath;
+    }
+    else if (!keyPath) {
+        return rootKeyPath;
     }
     else {
         return [NSString stringWithFormat:@"%@.%@", rootKeyPath, keyPath];

--- a/EasyMapping/XCTestCase+EasyMapping.m
+++ b/EasyMapping/XCTestCase+EasyMapping.m
@@ -1,0 +1,79 @@
+//
+//  XCTestCase+EasyMapping.m
+//  EasyMappingExample
+//
+//  Created by Ilya Puchka on 14.01.15.
+//  Copyright (c) 2015 EasyKit. All rights reserved.
+//
+
+#import "XCTestCase+EasyMapping.h"
+#import "EKPropertyHelper.h"
+#import "EKObjectMapping.h"
+#import "EKMapper.h"
+#import "EKSerializer.h"
+#import "EKRelationshipMapping.h"
+
+@implementation XCTestCase (EasyMapping)
+
+- (id)testMapping:(EKObjectMapping *)mapping withRepresentation:(NSDictionary *)representation expectedObject:(id)expectedObject
+{
+    return [self testMapping:mapping withRepresentation:representation expectedObject:expectedObject skippingKeyPaths:nil];
+}
+
+- (id)testMapping:(EKObjectMapping *)mapping withRepresentation:(NSDictionary *)representation expectedObject:(id)expectedObject skippingKeyPaths:(NSArray *)keyPathsToSkip
+{
+    id mappedObject = [EKMapper objectFromExternalRepresentation:representation withMapping:mapping];
+    NSMutableArray *keyPathsToCheck = [NSMutableArray new];
+    NSString *propertyKey = NSStringFromSelector(@selector(property));
+    [keyPathsToCheck addObjectsFromArray:[mapping.propertyMappings.allValues valueForKey:propertyKey]];
+    [keyPathsToCheck addObjectsFromArray:[mapping.hasOneMappings.allValues valueForKey:propertyKey]];
+    [keyPathsToCheck addObjectsFromArray:[mapping.hasManyMappings.allValues valueForKey:propertyKey]];
+    [keyPathsToCheck removeObjectsInArray:keyPathsToSkip];
+    
+    for (NSString *keyPath in keyPathsToCheck) {
+        id mappedValue = [mappedObject valueForKeyPath:keyPath];
+        id expectedValue = [expectedObject valueForKeyPath:keyPath];
+        XCTAssertEqualObjects(mappedValue, expectedValue, "Mapping failed on keypath %@. Expected value is - %@, value after mapping is - %@", keyPath, expectedValue, mappedValue);
+    }
+    return mappedObject;
+}
+
+- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping withObject:(id)object expectedRepresentation:(NSDictionary *)expectedRepresentation
+{
+    return [self testSerializationUsingMapping:mapping withObject:object expectedRepresentation:expectedRepresentation skippingKeyPaths:nil];
+}
+
+- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping withObject:(id)object expectedRepresentation:(NSDictionary *)expectedRepresentation skippingKeyPaths:(NSArray *)keyPathsToSkip
+{
+    NSDictionary *serializedObject = [EKSerializer serializeObject:object withMapping:mapping];
+    
+    NSMutableArray *keyPathsToCheck = [NSMutableArray new];
+    NSString *keyPathKey = NSStringFromSelector(@selector(keyPath));
+    [keyPathsToCheck addObjectsFromArray:[mapping.propertyMappings.allValues valueForKey:keyPathKey]];
+
+    [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping *relationshipMapping, BOOL *stop) {
+        if (relationshipMapping.keyPath) {
+            [keyPathsToCheck addObject:relationshipMapping.keyPath];
+        }
+        else {
+            NSMutableSet *keys = [NSMutableSet new];
+            [keys addObjectsFromArray:relationshipMapping.objectMapping.propertyMappings.allKeys];
+            [keys addObjectsFromArray:relationshipMapping.objectMapping.hasOneMappings.allKeys];
+            [keys addObjectsFromArray:relationshipMapping.objectMapping.hasManyMappings.allKeys];
+            [keyPathsToCheck addObjectsFromArray:keys.allObjects];
+        }
+    }];
+    
+    [keyPathsToCheck addObjectsFromArray:[mapping.hasManyMappings.allValues valueForKey:keyPathKey]];
+    [keyPathsToCheck removeObjectsInArray:keyPathsToSkip];
+    
+    for (NSString *keyPath in keyPathsToCheck) {
+        id mappedValue = [serializedObject valueForKeyPath:keyPath];
+        id expectedValue = [expectedRepresentation valueForKeyPath:keyPath];
+        XCTAssertEqualObjects(mappedValue, expectedValue, "Serialization failed on keypath %@. Expected value is - %@, value after serialization is - %@", keyPath, expectedValue, mappedValue);
+    }
+  
+    return serializedObject;
+}
+
+@end

--- a/EasyMapping/XCTestCase+EasyMapping.m
+++ b/EasyMapping/XCTestCase+EasyMapping.m
@@ -15,19 +15,19 @@
 
 @implementation XCTestCase (EasyMapping)
 
-- (id)testMapping:(EKObjectMapping *)mapping withRepresentation:(NSDictionary *)representation expectedObject:(id)expectedObject
+- (id)testObjectFromExternalRepresentation:(NSDictionary *)externalRepresentation withMapping:(EKObjectMapping *)mapping expectedObject:(id)expectedObject
 {
-    return [self testMapping:mapping withRepresentation:representation expectedObject:expectedObject skippingKeyPaths:nil];
+    return [self testObjectFromExternalRepresentation:externalRepresentation withMapping:mapping expectedObject:expectedObject skippingKeyPaths:nil];
 }
 
-- (id)testMapping:(EKObjectMapping *)mapping withRepresentation:(NSDictionary *)representation expectedObject:(id)expectedObject skippingKeyPaths:(NSArray *)keyPathsToSkip
+- (id)testObjectFromExternalRepresentation:(NSDictionary *)externalRepresentation withMapping:(EKObjectMapping *)mapping expectedObject:(id)expectedObject skippingKeyPaths:(NSArray *)keyPathsToSkip
 {
-    id mappedObject = [EKMapper objectFromExternalRepresentation:representation withMapping:mapping];
-    [self testMapping:mapping withMappedObject:mappedObject expectedObject:expectedObject skippingKeyPaths:keyPathsToSkip rootKeyPath:nil];
+    id mappedObject = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:mapping];
+    [self testMappedObject:mappedObject withMapping:mapping expectedObject:expectedObject skippingKeyPaths:keyPathsToSkip rootKeyPath:nil];
     return mappedObject;
 }
 
-- (void)testMapping:(EKObjectMapping *)mapping withMappedObject:(id)mappedObject expectedObject:(id)expectedObject skippingKeyPaths:(NSArray *)keyPathsToSkip rootKeyPath:(NSString *)rootKeyPath
+- (void)testMappedObject:(id)mappedObject withMapping:(EKObjectMapping *)mapping expectedObject:(id)expectedObject skippingKeyPaths:(NSArray *)keyPathsToSkip rootKeyPath:(NSString *)rootKeyPath
 {
     for (EKPropertyMapping *propertyMapping in mapping.propertyMappings.allValues) {
         NSString *keyPath = propertyMapping.property;
@@ -51,7 +51,7 @@
         NSArray *relationshipKeyPathsToSkip = [self extractRelationshipKeyPathsFromKeyPaths:keyPathsToSkip forRelationship:keyPath];
         NSString *relationshipRootKeyPath = [self keyPathByAppendingKeyPath:keyPath
                                                               toRootKeyPath:rootKeyPath];
-        [self testMapping:hasOneMapping.objectMapping withMappedObject:relationshipObject expectedObject:expectedRelationshipObject skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
+        [self testMappedObject:relationshipObject withMapping:hasOneMapping.objectMapping expectedObject:expectedRelationshipObject skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
     }
     
     for (EKRelationshipMapping *hasManyMapping in mapping.hasManyMappings.allValues) {
@@ -67,24 +67,24 @@
             NSString *indexKeyPath = [NSString stringWithFormat:@"%@[%lu]", keyPath, idx];
             NSString *relationshipRootKeyPath = [self keyPathByAppendingKeyPath:indexKeyPath
                                                                   toRootKeyPath:rootKeyPath];
-            [self testMapping:hasManyMapping.objectMapping withMappedObject:relationshipObject expectedObject:expectedRelationshipObject skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
+            [self testMappedObject:relationshipObject withMapping:hasManyMapping.objectMapping expectedObject:expectedRelationshipObject skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
         }];
     }
 }
 
-- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping withObject:(id)object expectedRepresentation:(NSDictionary *)expectedRepresentation
+- (NSDictionary *)testSerializeObject:(id)object withMapping:(EKObjectMapping *)mapping expectedRepresentation:(NSDictionary *)expectedRepresentation
 {
-    return [self testSerializationUsingMapping:mapping withObject:object expectedRepresentation:expectedRepresentation skippingKeyPaths:nil];
+    return [self testSerializeObject:object withMapping:mapping expectedRepresentation:expectedRepresentation skippingKeyPaths:nil];
 }
 
-- (NSDictionary *)testSerializationUsingMapping:(EKObjectMapping *)mapping withObject:(id)object expectedRepresentation:(NSDictionary *)expectedRepresentation skippingKeyPaths:(NSArray *)keyPathsToSkip
+- (NSDictionary *)testSerializeObject:(id)object withMapping:(EKObjectMapping *)mapping expectedRepresentation:(NSDictionary *)expectedRepresentation skippingKeyPaths:(NSArray *)keyPathsToSkip
 {
     NSDictionary *serializedObject = [EKSerializer serializeObject:object withMapping:mapping];
-    [self testSerializationUsingMapping:mapping withSerializedObject:serializedObject expectedRepresentation:expectedRepresentation skippingKeyPaths:keyPathsToSkip rootKeyPath:nil];
+    [self testSerializedObject:serializedObject withMapping:mapping expectedRepresentation:expectedRepresentation skippingKeyPaths:keyPathsToSkip rootKeyPath:nil];
     return serializedObject;
 }
 
-- (void)testSerializationUsingMapping:(EKObjectMapping *)mapping withSerializedObject:(NSDictionary *)serializedObject expectedRepresentation:(NSDictionary *)expectedRepresentation skippingKeyPaths:(NSArray *)keyPathsToSkip rootKeyPath:(NSString *)rootKeyPath
+- (void)testSerializedObject:(NSDictionary *)serializedObject withMapping:(EKObjectMapping *)mapping expectedRepresentation:(NSDictionary *)expectedRepresentation skippingKeyPaths:(NSArray *)keyPathsToSkip rootKeyPath:(NSString *)rootKeyPath
 {
     for (EKPropertyMapping *propertyMapping in mapping.propertyMappings.allValues) {
         NSString *keyPath = propertyMapping.keyPath;
@@ -108,10 +108,10 @@
             NSArray *relationshipKeyPathsToSkip = [self extractRelationshipKeyPathsFromKeyPaths:keyPathsToSkip forRelationship:keyPath];
             NSString *relationshipRootKeyPath = [self keyPathByAppendingKeyPath:keyPath
                                                                   toRootKeyPath:rootKeyPath];
-            [self testSerializationUsingMapping:hasOneMapping.objectMapping withSerializedObject:relationshipRepresentation expectedRepresentation:expectedRelationshipRepresentation skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
+            [self testSerializedObject:relationshipRepresentation withMapping:hasOneMapping.objectMapping expectedRepresentation:expectedRelationshipRepresentation skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
         }
         else {
-            [self testSerializationUsingMapping:hasOneMapping.objectMapping withSerializedObject:serializedObject expectedRepresentation:expectedRepresentation skippingKeyPaths:keyPathsToSkip rootKeyPath:rootKeyPath];
+            [self testSerializedObject:serializedObject withMapping:hasOneMapping.objectMapping expectedRepresentation:expectedRepresentation skippingKeyPaths:keyPathsToSkip rootKeyPath:rootKeyPath];
         }
     }
     
@@ -128,7 +128,7 @@
             NSString *indexKeyPath = [NSString stringWithFormat:@"%@[%lu]", keyPath, idx];
             NSString *relationshipRootKeyPath = [self keyPathByAppendingKeyPath:indexKeyPath
                                                                   toRootKeyPath:rootKeyPath];
-            [self testSerializationUsingMapping:hasManyMapping.objectMapping withSerializedObject:relationshipRepresentation expectedRepresentation:expectedRelationshipRepresentation skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
+            [self testSerializedObject:relationshipRepresentation withMapping:hasManyMapping.objectMapping expectedRepresentation:expectedRelationshipRepresentation skippingKeyPaths:relationshipKeyPathsToSkip rootKeyPath:relationshipRootKeyPath];
         }];
     }
 }

--- a/EasyMappingExample/Classes/Models/Car.m
+++ b/EasyMappingExample/Classes/Models/Car.m
@@ -22,4 +22,17 @@ static EKObjectMapping * mapping = nil;
     return mapping;
 }
 
+- (BOOL)isEqual:(Car *)object
+{
+    if (object == self) {
+        return YES;
+    }
+    if (![object isKindOfClass:[self class]]) {
+        return NO;
+    }
+    return (object.carId == self.carId &&
+            ([object.model isEqual:self.model] || (object.model == nil && self.model == nil)) &&
+            ([object.year isEqual:self.year] || (object.year == nil && self.year == nil)));
+}
+
 @end

--- a/EasyMappingExample/EasyMappingExample.xcodeproj/project.pbxproj
+++ b/EasyMappingExample/EasyMappingExample.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		097A5C551A670DFF00CB6CE3 /* XCTestCase+EasyMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 097A5C541A670DFF00CB6CE3 /* XCTestCase+EasyMapping.m */; };
+		097A5C5C1A67126900CB6CE3 /* EKMappingTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 097A5C5B1A67126900CB6CE3 /* EKMappingTestCase.m */; };
 		18BD8D6281D14C038CC3F308 /* libPods-MacOS Benchmark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4375CE2EA4B0479395A606A4 /* libPods-MacOS Benchmark.a */; };
 		550CE75226AD40059EA2F789 /* libPods-iOS Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEA1524818F4DC5B8950951 /* libPods-iOS Tests.a */; };
 		82DA805DFB1B4D3494041157 /* libPods-iOS Benchmark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 094E08F3DC3F4C88A8E2FBA5 /* libPods-iOS Benchmark.a */; };
@@ -274,6 +276,9 @@
 		02FF772618E32249002282D3 /* iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		07797FA26639AF90E877FABF /* Pods-MacOS Benchmark.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacOS Benchmark.release.xcconfig"; path = "Pods/Target Support Files/Pods-MacOS Benchmark/Pods-MacOS Benchmark.release.xcconfig"; sourceTree = "<group>"; };
 		094E08F3DC3F4C88A8E2FBA5 /* libPods-iOS Benchmark.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOS Benchmark.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		097A5C531A670DFF00CB6CE3 /* XCTestCase+EasyMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+EasyMapping.h"; sourceTree = "<group>"; };
+		097A5C541A670DFF00CB6CE3 /* XCTestCase+EasyMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCTestCase+EasyMapping.m"; sourceTree = "<group>"; };
+		097A5C5B1A67126900CB6CE3 /* EKMappingTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EKMappingTestCase.m; sourceTree = "<group>"; };
 		0FEA1524818F4DC5B8950951 /* libPods-iOS Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOS Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CAE9849457872E6F5681E97 /* Pods-OS X Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OS X Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		4375CE2EA4B0479395A606A4 /* libPods-MacOS Benchmark.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacOS Benchmark.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -510,6 +515,15 @@
 			path = EasyMappingExampleTests;
 			sourceTree = "<group>";
 		};
+		097A5C5A1A67126900CB6CE3 /* XCTests */ = {
+			isa = PBXGroup;
+			children = (
+				097A5C5B1A67126900CB6CE3 /* EKMappingTestCase.m */,
+			);
+			name = XCTests;
+			path = Tests/XCTests;
+			sourceTree = "<group>";
+		};
 		66C458DA179438FE005AF11E /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -694,6 +708,8 @@
 				A9D16D0316F2B2770003759B /* EKTransformer.m */,
 				9AA7CED5191FCFFE00608262 /* NSArray+FlattenArray.h */,
 				9AA7CED6191FCFFE00608262 /* NSArray+FlattenArray.m */,
+				097A5C531A670DFF00CB6CE3 /* XCTestCase+EasyMapping.h */,
+				097A5C541A670DFF00CB6CE3 /* XCTestCase+EasyMapping.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -810,6 +826,7 @@
 		9AF425C1190CEF42003FD1BD /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				097A5C5A1A67126900CB6CE3 /* XCTests */,
 				9A8420F219572382006DDDE3 /* FixtureClasses */,
 				9A4DD1AF190CF88C00A134C0 /* Specs */,
 				02FF773818E32257002282D3 /* Fixtures */,
@@ -1242,6 +1259,7 @@
 				9A4511EF191646F7006E6022 /* EKManagedObjectMappingSpec.m in Sources */,
 				9A4511E7191646F6006E6022 /* EKFieldMappingSpec.m in Sources */,
 				9A4511B0191646C9006E6022 /* Alien.m in Sources */,
+				097A5C5C1A67126900CB6CE3 /* EKMappingTestCase.m in Sources */,
 				9A45118E191646B2006E6022 /* ManagedPhone.m in Sources */,
 				9A2056A11956DF7900499FC3 /* BaseTestModel.m in Sources */,
 				9A45117819164696006E6022 /* ManagedMappingProvider.m in Sources */,
@@ -1254,6 +1272,7 @@
 				9A130249190BFEF30060A25C /* EKPropertyHelper.m in Sources */,
 				9A4511D4191646C9006E6022 /* Plane.m in Sources */,
 				9A45118A191646B2006E6022 /* ManagedPerson.m in Sources */,
+				097A5C551A670DFF00CB6CE3 /* XCTestCase+EasyMapping.m in Sources */,
 				9A4511D8191646C9006E6022 /* Seaplane.m in Sources */,
 				9A4511FF191646F7006E6022 /* EKSerializerSpec.m in Sources */,
 				9A4511C0191646C9006E6022 /* Finger.m in Sources */,

--- a/EasyMappingExample/Tests/XCTests/EKMappingTestCase.m
+++ b/EasyMappingExample/Tests/XCTests/EKMappingTestCase.m
@@ -41,7 +41,7 @@
     expectedCar.model = [externalRepresentation valueForKey:@"model"];
     expectedCar.year = [externalRepresentation valueForKey:@"year"];
 
-    [self testMapping:[Car objectMapping] withRepresentation:externalRepresentation expectedObject:expectedCar];
+    [self testObjectFromExternalRepresentation:externalRepresentation withMapping:[Car objectMapping] expectedObject:expectedCar];
 }
 
 - (void)testNonNestedMapping
@@ -60,7 +60,7 @@
     NSDictionary *genders = @{ @"male": @(GenderMale), @"female": @(GenderFemale) };
     expectedPerson.gender = (Gender)[genders[[externalRepresentation valueForKey:@"gender"]] integerValue];
     
-    [self testMapping:[Person objectMapping] withRepresentation:externalRepresentation expectedObject:expectedPerson];
+    [self testObjectFromExternalRepresentation:externalRepresentation withMapping:[Person objectMapping] expectedObject:expectedPerson];
 }
 
 - (void)testSimpleSerialization
@@ -74,7 +74,7 @@
     car.model = [expectedExternalRepresentation valueForKey:@"model"];
     car.year = [expectedExternalRepresentation valueForKey:@"year"];
     
-    [self testSerializationUsingMapping:[Car objectMapping] withObject:car expectedRepresentation:expectedExternalRepresentation];
+    [self testSerializeObject:car withMapping:[Car objectMapping] expectedRepresentation:expectedExternalRepresentation];
 }
 
 - (void)testNonNestedSerialization
@@ -93,7 +93,7 @@
     NSDictionary *genders = @{ @"male": @(GenderMale), @"female": @(GenderFemale) };
     person.gender = (Gender)[genders[[expectedExternalRepresentation valueForKey:@"gender"]] integerValue];
     
-    [self testSerializationUsingMapping:[Person objectMapping] withObject:person expectedRepresentation:expectedExternalRepresentation];
+    [self testSerializeObject:person withMapping:[Person objectMapping] expectedRepresentation:expectedExternalRepresentation];
 }
 
 - (void)testNestedSerialization
@@ -113,7 +113,7 @@
     NSDictionary *genders = @{ @"male": @(GenderMale), @"female": @(GenderFemale) };
     person.gender = (Gender)[genders[[expectedExternalRepresentation valueForKey:@"gender"]] integerValue];
     
-    [self testSerializationUsingMapping:[Person objectMapping] withObject:person expectedRepresentation:expectedExternalRepresentation skippingKeyPaths:@[@"phones"]];
+    [self testSerializeObject:person withMapping:[Person objectMapping] expectedRepresentation:expectedExternalRepresentation skippingKeyPaths:@[@"phones"]];
 }
 
 @end

--- a/EasyMappingExample/Tests/XCTests/EKMappingTestCase.m
+++ b/EasyMappingExample/Tests/XCTests/EKMappingTestCase.m
@@ -96,4 +96,24 @@
     [self testSerializationUsingMapping:[Person objectMapping] withObject:person expectedRepresentation:expectedExternalRepresentation];
 }
 
+- (void)testNestedSerialization
+{
+    NSDictionary *expectedExternalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+    
+    [Person registerMapping:[MappingProvider personMapping]];
+    [Car registerMapping:[MappingProvider carMapping]];
+    Person *person = [Person new];
+    Car *car = [Car new];
+    car.carId = [[expectedExternalRepresentation valueForKeyPath:@"car.id"] integerValue];
+    car.model = [expectedExternalRepresentation valueForKeyPath:@"car.model"];
+    car.year = [expectedExternalRepresentation valueForKeyPath:@"car.year"];
+    person.car = car;
+    person.name = [expectedExternalRepresentation valueForKey:@"name"];
+    person.email = [expectedExternalRepresentation valueForKey:@"email"];
+    NSDictionary *genders = @{ @"male": @(GenderMale), @"female": @(GenderFemale) };
+    person.gender = (Gender)[genders[[expectedExternalRepresentation valueForKey:@"gender"]] integerValue];
+    
+    [self testSerializationUsingMapping:[Person objectMapping] withObject:person expectedRepresentation:expectedExternalRepresentation skippingKeyPaths:@[@"phones"]];
+}
+
 @end

--- a/EasyMappingExample/Tests/XCTests/EKMappingTestCase.m
+++ b/EasyMappingExample/Tests/XCTests/EKMappingTestCase.m
@@ -1,0 +1,99 @@
+//
+//  EKMappingTestCase.m
+//  EasyMappingExample
+//
+//  Created by Ilya Puchka on 14.01.15.
+//  Copyright (c) 2015 EasyKit. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MappingProvider.h"
+#import "CMFixture.h"
+#import "XCTestCase+EasyMapping.h"
+
+#import "Car.h"
+#import "Person.h"
+
+@interface EKMappingTestCase : XCTestCase
+
+@end
+
+@implementation EKMappingTestCase
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testSimpleMapping
+{
+    NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Car"];
+    
+    [Car registerMapping:[MappingProvider carMapping]];
+
+    Car *expectedCar = [Car new];
+    expectedCar.carId = [[externalRepresentation valueForKey:@"id"] integerValue];
+    expectedCar.model = [externalRepresentation valueForKey:@"model"];
+    expectedCar.year = [externalRepresentation valueForKey:@"year"];
+
+    [self testMapping:[Car objectMapping] withRepresentation:externalRepresentation expectedObject:expectedCar];
+}
+
+- (void)testNonNestedMapping
+{
+    NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"PersonNonNested"];
+
+    [Person registerMapping:[MappingProvider personNonNestedMapping]];
+    Person *expectedPerson = [Person new];
+    Car *car = [Car new];
+    car.carId = [[externalRepresentation valueForKey:@"carId"] integerValue];
+    car.model = [externalRepresentation valueForKey:@"carModel"];
+    car.year = [externalRepresentation valueForKey:@"carYear"];
+    expectedPerson.car = car;
+    expectedPerson.name = [externalRepresentation valueForKey:@"name"];
+    expectedPerson.email = [externalRepresentation valueForKey:@"email"];
+    NSDictionary *genders = @{ @"male": @(GenderMale), @"female": @(GenderFemale) };
+    expectedPerson.gender = (Gender)[genders[[externalRepresentation valueForKey:@"gender"]] integerValue];
+    
+    [self testMapping:[Person objectMapping] withRepresentation:externalRepresentation expectedObject:expectedPerson];
+}
+
+- (void)testSimpleSerialization
+{
+    NSDictionary *expectedExternalRepresentation = [CMFixture buildUsingFixture:@"Car"];
+    
+    [Car registerMapping:[MappingProvider carMapping]];
+    
+    Car *car = [Car new];
+    car.carId = [[expectedExternalRepresentation valueForKey:@"id"] integerValue];
+    car.model = [expectedExternalRepresentation valueForKey:@"model"];
+    car.year = [expectedExternalRepresentation valueForKey:@"year"];
+    
+    [self testSerializationUsingMapping:[Car objectMapping] withObject:car expectedRepresentation:expectedExternalRepresentation];
+}
+
+- (void)testNonNestedSerialization
+{
+    NSDictionary *expectedExternalRepresentation = [CMFixture buildUsingFixture:@"PersonNonNested"];
+    
+    [Person registerMapping:[MappingProvider personNonNestedMapping]];
+    Person *person = [Person new];
+    Car *car = [Car new];
+    car.carId = [[expectedExternalRepresentation valueForKey:@"carId"] integerValue];
+    car.model = [expectedExternalRepresentation valueForKey:@"carModel"];
+    car.year = [expectedExternalRepresentation valueForKey:@"carYear"];
+    person.car = car;
+    person.name = [expectedExternalRepresentation valueForKey:@"name"];
+    person.email = [expectedExternalRepresentation valueForKey:@"email"];
+    NSDictionary *genders = @{ @"male": @(GenderMale), @"female": @(GenderFemale) };
+    person.gender = (Gender)[genders[[expectedExternalRepresentation valueForKey:@"gender"]] integerValue];
+    
+    [self testSerializationUsingMapping:[Person objectMapping] withObject:person expectedRepresentation:expectedExternalRepresentation];
+}
+
+@end


### PR DESCRIPTION
For those who use XCTest (like me) I think it will be convenient to have helper methods to remove tons of asserts from their test case method. I've added few methods for that, both for testing mapping and serialization. Base check is made using XCTAssertEqualObjects. Additionally you can skip some keyPaths and check them yourself using resulting object (model object or it's dictionary representation) returned from these helper methods.