### PR TITLE
Incremental parsing

### DIFF
--- a/EasyMapping/EKManagedObjectMapper.h
+++ b/EasyMapping/EKManagedObjectMapper.h
@@ -45,6 +45,24 @@
                 inManagedObjectContext:(NSManagedObjectContext*)context;
 
 /**
+ Creates object from JSON representation, using `mapping` in `context`.  If incrementalData is true, to-many relationship data is pushed to the existing data instead of replaced.
+ 
+ @param externalRepresentation JSON representation of object data
+ 
+ @param mapping object mapping
+ 
+ @param context managed object context to perform object creation
+ 
+ @param incrementalData Defines if to-many relationship data is pushed or replaced
+
+ @result mapped managed object
+ */
++ (id)objectFromExternalRepresentation:(NSDictionary *)externalRepresentation
+                           withMapping:(EKManagedObjectMapping *)mapping
+                inManagedObjectContext:(NSManagedObjectContext*)context
+                       incrementalData:(BOOL)incrementalData;
+
+/**
  Fills previously existed object with values, provided in JSON representation. All values, that are included in mapping and were filled prior to calling this method, will be overwritten.
  
  @param object Object to fill
@@ -63,6 +81,27 @@
       inManagedObjectContext:(NSManagedObjectContext*)context;
 
 /**
+ Fills previously existed object with values, provided in JSON representation. All values, that are included in mapping and were filled prior to calling this method, will be overwritten. If incrementalData is true, to-many relationship data is pushed to the existing data instead of replaced.
+ 
+ @param object Object to fill
+ 
+ @param externalRepresentation JSON representation of object data
+ 
+ @param mapping object mapping
+ 
+ @param context managed object context to perform object creation
+
+ @param incrementalData Defines if to-many relationship data is pushed or replaced
+
+ @result filled managed object
+ */
++ (id)            fillObject:(id)object
+  fromExternalRepresentation:(NSDictionary *)externalRepresentation
+                 withMapping:(EKManagedObjectMapping *)mapping
+      inManagedObjectContext:(NSManagedObjectContext*)context
+             incrementalData:(BOOL)incrementalData;
+
+/**
  Create array of CoreData objects. If passed JSON contains primary keys, previously existing object with these keys will be updated. Simply put, this method uses Find-Or-Create pattern.
  
  @param externalRepresentation JSON array with objects
@@ -76,6 +115,24 @@
 + (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                           withMapping:(EKManagedObjectMapping *)mapping
                                inManagedObjectContext:(NSManagedObjectContext*)context;
+
+/**
+ Create array of CoreData objects. If passed JSON contains primary keys, previously existing object with these keys will be updated. Simply put, this method uses Find-Or-Create pattern. If incrementalData is true, to-many relationship data is pushed to the existing data instead of replaced.
+ 
+ @param externalRepresentation JSON array with objects
+ 
+ @param mapping object mapping
+ 
+ @param context managed object context to perform objects creation
+ 
+ @param incrementalData Defines if to-many relationship data is pushed or replaced
+ 
+ @result array of managed objects
+ */
++ (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
+                                          withMapping:(EKManagedObjectMapping *)mapping
+                               inManagedObjectContext:(NSManagedObjectContext*)context
+                                     incrementalData:(BOOL)incrementalData;
 
 /** 
  Synchronize the objects in the managed object context with the objects from an external
@@ -97,5 +154,30 @@
                                               withMapping:(EKManagedObjectMapping *)mapping
                                              fetchRequest:(NSFetchRequest*)fetchRequest
                                    inManagedObjectContext:(NSManagedObjectContext *)context;
+
+/**
+ Synchronize the objects in the managed object context with the objects from an external
+ representation. Any new objects will be created, any existing objects will be updated
+ and any object not present in the external representation will be deleted from the
+ managed object context. The fetch request is used to pre-fetch all existing objects.
+ If incrementalData is true, to-many relationship data is pushed to the existing data instead of replaced.
+ 
+ @param externalRepresentation JSON array with objects
+ 
+ @param mapping object mapping
+ 
+ @param fetchRequest Fetch request to get existing objects
+ 
+ @param context managed object context to perform objects creation
+ 
+ @param incrementalData Defines if to-many relationship data is pushed or replaced
+ 
+ @result array of managed objects
+ */
++ (NSArray *)syncArrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
+                                              withMapping:(EKManagedObjectMapping *)mapping
+                                             fetchRequest:(NSFetchRequest*)fetchRequest
+                                   inManagedObjectContext:(NSManagedObjectContext *)context
+                                          incrementalData:(BOOL)incrementalData;
 
 @end

--- a/EasyMapping/EKManagedObjectMapper.m
+++ b/EasyMapping/EKManagedObjectMapper.m
@@ -44,6 +44,7 @@
 
 - (id)objectFromExternalRepresentation:(NSDictionary *)externalRepresentation
                            withMapping:(EKManagedObjectMapping *)mapping
+                       incrementalData:(BOOL)incrementalData
 {
     NSManagedObject * object = [self.importer existingObjectForRepresentation:externalRepresentation
                                                                       mapping:mapping
@@ -55,7 +56,8 @@
     }
     NSManagedObject * filledObject = [self fillObject:object
                            fromExternalRepresentation:externalRepresentation
-                                          withMapping:mapping];
+                                          withMapping:mapping
+                                      incrementalData:incrementalData];
     [self.importer cacheObject:filledObject withMapping:mapping];
     
     return filledObject;
@@ -63,6 +65,7 @@
 
 - (id)fillObject:(id)object fromExternalRepresentation:(NSDictionary *)externalRepresentation
      withMapping:(EKManagedObjectMapping *)mapping
+ incrementalData:(BOOL)incrementalData
 {
     NSDictionary * representation = [EKPropertyHelper extractRootPathFromExternalRepresentation:externalRepresentation
                                                                                     withMapping:mapping];
@@ -78,7 +81,7 @@
         NSDictionary * value = [representation valueForKeyPath:key];
         if (value && value != (id)[NSNull null])
         {
-            id result = [self objectFromExternalRepresentation:value withMapping:(EKManagedObjectMapping *)[mapping objectMapping]];
+            id result = [self objectFromExternalRepresentation:value withMapping:(EKManagedObjectMapping *)[mapping objectMapping] incrementalData:incrementalData];
             [EKPropertyHelper setValue:result onObject:object forKeyPath:mapping.property];
         }
     }];
@@ -88,11 +91,17 @@
         if (arrayToBeParsed && arrayToBeParsed != (id)[NSNull null])
         {
             NSArray * parsedArray = [self arrayOfObjectsFromExternalRepresentation:arrayToBeParsed
-                                                                       withMapping:(EKManagedObjectMapping *)[mapping objectMapping]];
+                                                                       withMapping:(EKManagedObjectMapping *)[mapping objectMapping]
+                                                                   incrementalData:incrementalData];
             id parsedObjects = [EKPropertyHelper propertyRepresentation:parsedArray
                                                               forObject:object
                                                        withPropertyName:[mapping property]];
-            [EKPropertyHelper setValue:parsedObjects onObject:object forKeyPath:mapping.property];
+            if(incrementalData) {
+                [EKPropertyHelper addValue:parsedObjects onObject:object forKeyPath:mapping.property];
+            }
+            else {
+                [EKPropertyHelper setValue:parsedObjects onObject:object forKeyPath:mapping.property];
+            }
         }
     }];
     return object;
@@ -100,12 +109,13 @@
 
 - (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                           withMapping:(EKManagedObjectMapping *)mapping
+                                      incrementalData:(BOOL)incrementalData
 {
 
     NSMutableArray * array = [NSMutableArray array];
     for (NSDictionary * representation in externalRepresentation)
     {
-        id parsedObject = [self objectFromExternalRepresentation:representation withMapping:mapping];
+        id parsedObject = [self objectFromExternalRepresentation:representation withMapping:mapping incrementalData:incrementalData];
         [array addObject:parsedObject];
     }
     return [NSArray arrayWithArray:array];
@@ -114,6 +124,7 @@
 - (NSArray *)syncArrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                               withMapping:(EKManagedObjectMapping *)mapping
                                              fetchRequest:(NSFetchRequest *)fetchRequest
+                                          incrementalData:(BOOL)incrementalData
 {
     NSAssert(mapping.primaryKey, @"A mapping with a primary key is required");
     EKPropertyMapping * primaryKeyPropertyMapping = [mapping primaryKeyPropertyMapping];
@@ -137,7 +148,7 @@
             object = [NSEntityDescription insertNewObjectForEntityForName:mapping.entityName
                                                    inManagedObjectContext:self.importer.context];
 
-        [self fillObject:object fromExternalRepresentation:representation withMapping:mapping];
+        [self fillObject:object fromExternalRepresentation:representation withMapping:mapping incrementalData:incrementalData];
         [array addObject:object];
     }
 
@@ -160,6 +171,17 @@
                            withMapping:(EKManagedObjectMapping *)mapping
                 inManagedObjectContext:(NSManagedObjectContext *)context
 {
+    return [self objectFromExternalRepresentation:externalRepresentation
+                                      withMapping:mapping
+                           inManagedObjectContext:context
+                                  incrementalData:NO];
+}
+
++ (id)objectFromExternalRepresentation:(NSDictionary *)externalRepresentation
+                           withMapping:(EKManagedObjectMapping *)mapping
+                inManagedObjectContext:(NSManagedObjectContext *)context
+                       incrementalData:(BOOL)incrementalData
+{
     NSParameterAssert([mapping isKindOfClass:[EKManagedObjectMapping class]]);
     NSParameterAssert(context);
     
@@ -167,13 +189,27 @@
                                                      externalRepresentation:externalRepresentation
                                                                     context:context];
     return [[self mapperWithImporter:importer] objectFromExternalRepresentation:externalRepresentation
-                                                                    withMapping:mapping];
+                                                                    withMapping:mapping
+                                                                incrementalData:incrementalData];
 }
 
 + (id)          fillObject:(id)object
 fromExternalRepresentation:(NSDictionary *)externalRepresentation
                withMapping:(EKManagedObjectMapping *)mapping
     inManagedObjectContext:(NSManagedObjectContext *)context
+{
+    return [self fillObject:object
+ fromExternalRepresentation:externalRepresentation
+                withMapping:mapping
+     inManagedObjectContext:context
+            incrementalData:NO];
+}
+
++ (id)            fillObject:(id)object
+  fromExternalRepresentation:(NSDictionary *)externalRepresentation
+                 withMapping:(EKManagedObjectMapping *)mapping
+      inManagedObjectContext:(NSManagedObjectContext*)context
+             incrementalData:(BOOL)incrementalData
 {
     NSParameterAssert([mapping isKindOfClass:[EKManagedObjectMapping class]]);
     NSParameterAssert(context);
@@ -183,12 +219,24 @@ fromExternalRepresentation:(NSDictionary *)externalRepresentation
                                                                     context:context];
     return [[self mapperWithImporter:importer] fillObject:object
                                fromExternalRepresentation:externalRepresentation
-                                              withMapping:mapping];
+                                              withMapping:mapping
+                                          incrementalData:incrementalData];
 }
 
 + (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                           withMapping:(EKManagedObjectMapping *)mapping
                                inManagedObjectContext:(NSManagedObjectContext *)context
+{
+    return [self arrayOfObjectsFromExternalRepresentation:externalRepresentation
+                                              withMapping:mapping
+                                   inManagedObjectContext:context
+                                         incrementalData:NO];
+}
+
++ (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
+                                          withMapping:(EKManagedObjectMapping *)mapping
+                               inManagedObjectContext:(NSManagedObjectContext*)context
+                                     incrementalData:(BOOL)incrementalData
 {
     NSParameterAssert([mapping isKindOfClass:[EKManagedObjectMapping class]]);
     NSParameterAssert(context);
@@ -196,14 +244,29 @@ fromExternalRepresentation:(NSDictionary *)externalRepresentation
     EKCoreDataImporter * importer = [EKCoreDataImporter importerWithMapping:mapping
                                                      externalRepresentation:externalRepresentation
                                                                     context:context];
+
     return [[self mapperWithImporter:importer] arrayOfObjectsFromExternalRepresentation:externalRepresentation
-                                                                            withMapping:mapping];
+                                                                            withMapping:mapping
+                                                                        incrementalData:incrementalData];
 }
 
 + (NSArray *)syncArrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                               withMapping:(EKManagedObjectMapping *)mapping
                                              fetchRequest:(NSFetchRequest *)fetchRequest
                                    inManagedObjectContext:(NSManagedObjectContext *)context
+{
+    return [self syncArrayOfObjectsFromExternalRepresentation:externalRepresentation
+                                                  withMapping:mapping
+                                                 fetchRequest:fetchRequest
+                                       inManagedObjectContext:context
+                                              incrementalData:NO];
+}
+
++ (NSArray *)syncArrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
+                                              withMapping:(EKManagedObjectMapping *)mapping
+                                             fetchRequest:(NSFetchRequest *)fetchRequest
+                                   inManagedObjectContext:(NSManagedObjectContext *)context
+                                          incrementalData:(BOOL)incrementalData
 {
     NSParameterAssert([mapping isKindOfClass:[EKManagedObjectMapping class]]);
     NSParameterAssert(context);
@@ -213,7 +276,8 @@ fromExternalRepresentation:(NSDictionary *)externalRepresentation
                                                                     context:context];
     return [[self mapperWithImporter:importer] syncArrayOfObjectsFromExternalRepresentation:externalRepresentation
                                                                                 withMapping:mapping
-                                                                               fetchRequest:fetchRequest];
+                                                                               fetchRequest:fetchRequest
+                                                                            incrementalData:incrementalData];
 }
 
 @end

--- a/EasyMapping/EKMapper.h
+++ b/EasyMapping/EKMapper.h
@@ -42,7 +42,7 @@
                            withMapping:(EKObjectMapping *)mapping;
 
 /**
- Fills previously existed object with values, provided in JSON representation. All values, that are included in mapping and were filled prior to calling this method, will be overwritten. 
+ Fills previously existed object with values, provided in JSON representation. All values, that are included in mapping and were filled prior to calling this method, will be overwritten.
  
  @param object Object to fill 
  
@@ -55,6 +55,24 @@
 + (id)            fillObject:(id)object
   fromExternalRepresentation:(NSDictionary *)externalRepresentation
                  withMapping:(EKObjectMapping *)mapping;
+
+/**
+ Fills previously existed object with values, provided in JSON representation. All values, that are included in mapping and were filled prior to calling this method, will be overwritten. If incrementalData is true, to-many relationship data is pushed to the existing data instead of replaced.
+ 
+ @param object Object to fill
+ 
+ @param externalRepresentation JSON representation of object data
+ 
+ @param mapping object mapping
+ 
+ @param incrementalData Defines if to-many relationship data is pushed or replaced
+ 
+ @result filled object
+ */
++ (id)            fillObject:(id)object
+  fromExternalRepresentation:(NSDictionary *)externalRepresentation
+                 withMapping:(EKObjectMapping *)mapping
+             incrementalData:(BOOL)incrementalData;
 
 /**
  Convenience method to create array of objects from JSON.

--- a/EasyMapping/EKMapper.m
+++ b/EasyMapping/EKMapper.m
@@ -40,11 +40,18 @@
     }
     
     id object = [[mapping.objectClass alloc] init];
-    return [self fillObject:object fromExternalRepresentation:externalRepresentation withMapping:mapping];
+    return [self fillObject:object fromExternalRepresentation:externalRepresentation withMapping:mapping incrementalData:NO];
 }
 
 + (id)fillObject:(id)object fromExternalRepresentation:(NSDictionary *)externalRepresentation
      withMapping:(EKObjectMapping *)mapping
+{
+    return [self fillObject:object fromExternalRepresentation:externalRepresentation withMapping:mapping incrementalData:NO];
+}
+
++ (id)fillObject:(id)object fromExternalRepresentation:(NSDictionary *)externalRepresentation
+     withMapping:(EKObjectMapping *)mapping
+ incrementalData:(BOOL)incrementalData
 {
     NSDictionary *representation = [EKPropertyHelper extractRootPathFromExternalRepresentation:externalRepresentation withMapping:mapping];
     [mapping.propertyMappings enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -70,8 +77,17 @@
              id parsedObjects = [EKPropertyHelper propertyRepresentation:parsedArray
                                                                forObject:object
                                                         withPropertyName:[valueMapping property]];
-			 [object setValue:parsedObjects forKeyPath:valueMapping.property];
-		 } else {
+
+             id _value = [object valueForKeyPath:valueMapping.property];
+             
+             if(incrementalData && _value!=nil) {
+                 _value = [_value arrayByAddingObjectsFromArray:parsedObjects];
+                 [object setValue:_value forKey:valueMapping.property];
+             }
+             else {
+                 [object setValue:parsedObjects forKeyPath:valueMapping.property];
+             }
+		 } else if(!incrementalData) {
 			 [object setValue:nil forKey:valueMapping.property];
 		 }
     }];
@@ -81,8 +97,6 @@
 + (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                           withMapping:(EKObjectMapping *)mapping
 {
-    NSParameterAssert([mapping isKindOfClass:[EKObjectMapping class]]);
-    
     if (![externalRepresentation isKindOfClass:[NSArray class]] ||
         ![mapping isKindOfClass:[EKObjectMapping class]]) {
         return nil;

--- a/EasyMapping/EKPropertyHelper.h
+++ b/EasyMapping/EKPropertyHelper.h
@@ -53,6 +53,8 @@ fromRepresentation:(NSDictionary *)representation;
 
 + (void)setValue:(id)value onObject:(id)object forKeyPath:(NSString *)keyPath;
 
++ (void)addValue:(id)value onObject:(id)object forKeyPath:(NSString *)keyPath;
+
 + (NSDictionary *)extractRootPathFromExternalRepresentation:(NSDictionary *)externalRepresentation
                                                 withMapping:(EKObjectMapping *)mapping;
 

--- a/EasyMapping/EKPropertyHelper.m
+++ b/EasyMapping/EKPropertyHelper.m
@@ -140,6 +140,28 @@ static const char scalarTypes[] = {
     }
 }
 
++(void)addValue:(id)value onObject:(id)object forKeyPath:(NSString *)keyPath
+{
+    id _value = [object valueForKeyPath:keyPath];
+    if(![_value isKindOfClass:[NSSet class]]) {
+        [self setValue:value onObject:object forKeyPath:keyPath];
+    }
+    else {
+        if ([(id <NSObject>)object isKindOfClass:[NSManagedObject class]])
+        {
+            // Reducing update times in CoreData
+            if(_value != value && ![value isSubsetOfSet:_value]) {
+                _value = [_value setByAddingObjectsFromSet:value];
+                [object setValue:_value forKey:keyPath];
+            }
+        }
+        else {
+            _value = [_value setByAddingObjectsFromSet:value];
+            [object setValue:_value forKey:keyPath];
+        }
+    }
+}
+
 + (id)getValueOfProperty:(EKPropertyMapping *)propertyMapping fromRepresentation:(NSDictionary *)representation
 {
     id value = nil;

--- a/EasyMappingExample/EasyMappingExample.xcodeproj/project.pbxproj
+++ b/EasyMappingExample/EasyMappingExample.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		18BD8D6281D14C038CC3F308 /* libPods-MacOS Benchmark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4375CE2EA4B0479395A606A4 /* libPods-MacOS Benchmark.a */; };
+		49498DD31A4C41F900158E19 /* PersonWithOtherPhones.json in Resources */ = {isa = PBXBuildFile; fileRef = 49498DD21A4C41F900158E19 /* PersonWithOtherPhones.json */; };
+		49498DD51A4C492300158E19 /* PersonWithZeroPhones.json in Resources */ = {isa = PBXBuildFile; fileRef = 49498DD41A4C492300158E19 /* PersonWithZeroPhones.json */; };
 		550CE75226AD40059EA2F789 /* libPods-iOS Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FEA1524818F4DC5B8950951 /* libPods-iOS Tests.a */; };
 		82DA805DFB1B4D3494041157 /* libPods-iOS Benchmark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 094E08F3DC3F4C88A8E2FBA5 /* libPods-iOS Benchmark.a */; };
 		9A13023D190BFBCA0060A25C /* EasyMappingExample.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9AE54FE5190BD9B5003A3B56 /* EasyMappingExample.xcdatamodeld */; };
@@ -275,6 +277,8 @@
 		0FEA1524818F4DC5B8950951 /* libPods-iOS Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOS Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CAE9849457872E6F5681E97 /* Pods-OS X Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OS X Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		4375CE2EA4B0479395A606A4 /* libPods-MacOS Benchmark.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacOS Benchmark.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		49498DD21A4C41F900158E19 /* PersonWithOtherPhones.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PersonWithOtherPhones.json; path = Tests/Fixtures/PersonWithOtherPhones.json; sourceTree = SOURCE_ROOT; };
+		49498DD41A4C492300158E19 /* PersonWithZeroPhones.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PersonWithZeroPhones.json; path = Tests/Fixtures/PersonWithZeroPhones.json; sourceTree = SOURCE_ROOT; };
 		5D5068BD028D7ECDE8912D21 /* Pods-iOS Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS Tests/Pods-iOS Tests.release.xcconfig"; sourceTree = "<group>"; };
 		8D816FFC6DC094C7A9297EA6 /* Pods-iOS Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS Tests/Pods-iOS Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		9A130226190BF9380060A25C /* OS X Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OS X Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -497,6 +501,8 @@
 				9A45120F19164705006E6022 /* PersonWithDifferentNaming.json */,
 				9A45121019164705006E6022 /* PersonWithNullCar.json */,
 				9A45121119164705006E6022 /* PersonWithNullPhones.json */,
+				49498DD41A4C492300158E19 /* PersonWithZeroPhones.json */,
+				49498DD21A4C41F900158E19 /* PersonWithOtherPhones.json */,
 				9A45121219164705006E6022 /* Plane.json */,
 				9AA7CED2191FA7C400608262 /* ComplexRepresentation.json */,
 				9A210F361944B13A00871071 /* CommentsRecursive.json */,
@@ -999,12 +1005,14 @@
 			files = (
 				9A45121319164705006E6022 /* Address.json in Resources */,
 				9A45122F19164705006E6022 /* Female.json in Resources */,
+				49498DD51A4C492300158E19 /* PersonWithZeroPhones.json in Resources */,
 				9A45123319164705006E6022 /* Male.json in Resources */,
 				9AA7CED3191FA7C400608262 /* ComplexRepresentation.json in Resources */,
 				9AC1321D1A2CA193001ED491 /* PersonsWithSamePhones.json in Resources */,
 				9A210F371944B13A00871071 /* CommentsRecursive.json in Resources */,
 				9A45123F19164705006E6022 /* Person.json in Resources */,
 				9A45122319164705006E6022 /* CarWithDate.json in Resources */,
+				49498DD31A4C41F900158E19 /* PersonWithOtherPhones.json in Resources */,
 				9A45121B19164705006E6022 /* Car.json in Resources */,
 				9A45123719164705006E6022 /* Native.json in Resources */,
 				9A45125919164773006E6022 /* InfoPlist.strings in Resources */,

--- a/EasyMappingExample/Tests/Fixtures/PersonWithOtherPhones.json
+++ b/EasyMappingExample/Tests/Fixtures/PersonWithOtherPhones.json
@@ -1,0 +1,25 @@
+{
+    "id":23,
+    "name": "Lucas",
+    "email": "lucastoc@gmail.com",
+    "gender" : "male",
+    "car": {
+        "id":3,
+        "model": "i30",
+        "year": "2013"
+    },
+    "phones": [
+        {
+            "id":3,
+            "ddi": "55",
+            "ddd": "85",
+            "number": "3333-333"
+        },
+        {
+            "id":4,
+            "ddi": "55",
+            "ddd": "11",
+            "number": "4444-444"
+        }
+    ]
+}

--- a/EasyMappingExample/Tests/Fixtures/PersonWithZeroPhones.json
+++ b/EasyMappingExample/Tests/Fixtures/PersonWithZeroPhones.json
@@ -8,5 +8,5 @@
         "model": "i30",
         "year": "2013"
     },
-    "phones": null
+    "phones": []
 }

--- a/EasyMappingExample/Tests/Specs/EKCoreDataImporterSpec.m
+++ b/EasyMappingExample/Tests/Specs/EKCoreDataImporterSpec.m
@@ -163,7 +163,7 @@ describe(@"Entities introspection", ^{
         importer = [EKCoreDataImporter importerWithMapping:[ManagedMappingProvider personMapping] externalRepresentation:externalRepresentation context:nil];
         
         NSSet * cars = [NSSet setWithObject:@56];
-        NSSet * people = [NSSet set];
+        NSSet * people = [NSSet setWithObject:@23];
         NSSet * phones = [NSSet set];
         
         [[importer.existingEntitiesPrimaryKeys should] equal:@{@"ManagedCar":cars,

--- a/EasyMappingExample/Tests/Specs/EKManagedObjectMapperSpec.m
+++ b/EasyMappingExample/Tests/Specs/EKManagedObjectMapperSpec.m
@@ -306,6 +306,125 @@ describe(@"EKManagedObjectMapper", ^{
         
     });
     
+    describe(@".objectFromExternalRepresentation:withMapping:incrementalData:", ^{
+        context(@"with hasMany mapping", ^{
+            
+            __block NSManagedObjectContext* moc;
+            __block ManagedPerson *person;
+            
+            beforeEach(^{
+                moc = [NSManagedObjectContext MR_defaultContext];
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:YES];
+            });
+            
+            specify(^{
+                [person.phones shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:2];
+            });
+            
+        });
+        context(@"with hasMany mapping and incremental data", ^{
+            
+            __block NSManagedObjectContext* moc;
+            __block ManagedPerson *person;
+            
+            beforeEach(^{
+                moc = [NSManagedObjectContext MR_defaultContext];
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:NO];
+                
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithOtherPhones"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:NO];
+                
+            });
+            
+            specify(^{
+                [person.phones shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:2];
+            });
+            
+        });
+        context(@"with hasMany mapping and incremental data", ^{
+            
+            __block NSManagedObjectContext* moc;
+            __block ManagedPerson *person;
+            
+            beforeEach(^{
+                moc = [NSManagedObjectContext MR_defaultContext];
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:YES];
+                
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithOtherPhones"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:YES];
+                
+            });
+            
+            specify(^{
+                [person.phones shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:4];
+            });
+            
+        });
+        context(@"with hasMany mapping empty and not incremental data", ^{
+            
+            __block NSManagedObjectContext* moc;
+            __block ManagedPerson *person;
+            
+            beforeEach(^{
+                moc = [NSManagedObjectContext MR_defaultContext];
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:NO];
+                
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithZeroPhones"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:NO];
+                
+            });
+            
+            specify(^{
+                [person.phones shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:0];
+            });
+            
+        });
+        context(@"with hasMany mapping empty and incremental data", ^{
+            
+            __block NSManagedObjectContext* moc;
+            __block ManagedPerson *person;
+            
+            beforeEach(^{
+                moc = [NSManagedObjectContext MR_defaultContext];
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:NO];
+                
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithZeroPhones"];
+                person = [EKManagedObjectMapper objectFromExternalRepresentation:externalRepresentation withMapping:[ManagedMappingProvider personMapping] inManagedObjectContext:moc incrementalData:YES];
+                
+            });
+            
+            specify(^{
+                [person.phones shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:2];
+            });
+            
+        });
+    });
+
     describe(@".arrayOfObjectsFromExternalRepresentation:withMapping:", ^{
         
         __block NSManagedObjectContext* moc;

--- a/EasyMappingExample/Tests/Specs/EKMapperSpec.m
+++ b/EasyMappingExample/Tests/Specs/EKMapperSpec.m
@@ -348,7 +348,99 @@ describe(@"EKMapper", ^{
 				 [[person.car shouldNot] beNil];
 			 });
 		 });
-		 
+
+        context(@"with hasMany mapping and not incrementalData", ^{
+            __block Person* person;
+            
+            beforeEach(^{
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithOtherPhones"];
+                person = [EKMapper fillObject:person fromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping] incrementalData:NO];
+            });
+            
+            specify(^{
+                [[person shouldNot] beNil];
+            });
+
+            specify(^{
+                [[person.phones shouldNot] beNil];
+            });
+
+            specify(^{
+                [[person.phones should] haveCountOf:2];
+            });
+        });
+
+        context(@"with hasMany mapping and incrementalData", ^{
+            __block Person* person;
+            
+            beforeEach(^{
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithOtherPhones"];
+                person = [EKMapper fillObject:person fromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping] incrementalData:YES];
+            });
+            
+            specify(^{
+                [[person shouldNot] beNil];
+            });
+            
+            specify(^{
+                [[person.phones shouldNot] beNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:4];
+            });
+        });
+
+        context(@"with hasMany mapping empty and not incrementalData", ^{
+            __block Person* person;
+            
+            beforeEach(^{
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithZeroPhones"];
+                person = [EKMapper fillObject:person fromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping] incrementalData:NO];
+            });
+            
+            specify(^{
+                [[person shouldNot] beNil];
+            });
+            
+            specify(^{
+                [[person.phones shouldNot] beNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:0];
+            });
+        });
+        
+        context(@"with hasMany mapping empty and incrementalData", ^{
+            __block Person* person;
+            
+            beforeEach(^{
+                NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"Person"];
+                person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
+                externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithZeroPhones"];
+                person = [EKMapper fillObject:person fromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping] incrementalData:YES];
+            });
+            
+            specify(^{
+                [[person shouldNot] beNil];
+            });
+            
+            specify(^{
+                [[person.phones shouldNot] beNil];
+            });
+            
+            specify(^{
+                [[person.phones should] haveCountOf:2];
+            });
+        });
+        
 		 context(@"with hasOne mapping NULL in representation", ^{
 			 __block Person* person;
 			 


### PR DESCRIPTION
In the API I connect sometime I get updates as incremental data. That means only updated data is included in the response. For regular properties and to-one relations this all works fine since missing properties doesn't result in removing any data. However for to-many relations this didn't work as required. This pull request provides additional Object Mapper methods where you can select if it's incremental data or not. Setting incremental data means no relations are deleted, only updated or added. Below this is illustrated:

Suppose you start with the following data
```
{
   "to-many-relation": [
      {"object1":1}, 
      {"object2":2}
   ]
}
```

The update contains:
```
{
   "to-many-relation": [
      {"object2":4}, 
      {"object3":3}
   ]
}
```

Without incremental data you get:
```
{
   "to-many-relation": [
      {"object2":4}, 
      {"object3":3}
   ]
}
```

With incremental data you get:
```
{
   "to-many-relation": [
      {"object1":1}, 
      {"object2":4}, 
      {"object3":3}
   ]
}
```
