### PR TITLE
Fix crash on recursive relation for Core Data

### DIFF
--- a/EasyMapping/EKCoreDataImporter.m
+++ b/EasyMapping/EKCoreDataImporter.m
@@ -169,7 +169,12 @@
             // @[<null>,@[value2,value3]]
             //
             // And we are interested in flat structure like this: @[value2,value3]
-            manyMappingRepresentation = [manyMappingRepresentation ek_flattenedArray];
+            manyMappingRepresentation = [manyMappingRepresentation ek_flattenedCompactedArray];
+
+            // if after compact, the array is empty, we should skip this
+            if ([manyMappingRepresentation count] == 0) {
+                return;
+            }
 
             [self inspectRepresentation:manyMappingRepresentation
                            usingMapping:(EKManagedObjectMapping *)[mapping objectMapping]

--- a/EasyMapping/EKCoreDataImporter.m
+++ b/EasyMapping/EKCoreDataImporter.m
@@ -148,9 +148,23 @@
 
     [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * mapping, BOOL * stop)
     {
-        NSDictionary * oneMappingRepresentation = [rootRepresentation valueForKeyPath:key];
+        id oneMappingRepresentation = [rootRepresentation valueForKeyPath:key];
         if (oneMappingRepresentation && ![oneMappingRepresentation isEqual:[NSNull null]])
         {
+            // This is needed, because if one of the objects in array does not contain object for key, returned structure would be something like this:
+            //
+            // @[<null>,@[value2,value3]]
+            //
+            // And we are interested in flat structure like this: @[value2,value3]
+            if ([oneMappingRepresentation isKindOfClass:[NSArray class]]) {
+                oneMappingRepresentation = [oneMappingRepresentation ek_flattenedCompactedArray];
+
+                // if after compact, the array is empty, we should skip this
+                if ([oneMappingRepresentation count] == 0) {
+                    return;
+                }
+            }
+
             [self inspectRepresentation:oneMappingRepresentation
                            usingMapping:(EKManagedObjectMapping *)[mapping objectMapping]
                        accumulateInside:dictionary

--- a/EasyMapping/NSArray+FlattenArray.h
+++ b/EasyMapping/NSArray+FlattenArray.h
@@ -25,6 +25,6 @@
 
 @interface NSArray (FlattenArray)
 
--(NSArray*)ek_flattenedArray;
+-(NSArray*)ek_flattenedCompactedArray;
 
 @end

--- a/EasyMapping/NSArray+FlattenArray.m
+++ b/EasyMapping/NSArray+FlattenArray.m
@@ -25,12 +25,12 @@
 
 @implementation NSArray (FlattenArray)
 
--(NSArray*)ek_flattenedArray {
+-(NSArray*)ek_flattenedCompactedArray {
     NSMutableArray *result = [NSMutableArray arrayWithCapacity:self.count];
     for (id thing in self) {
         if ([thing isKindOfClass:[NSArray class]]) {
-            [result addObjectsFromArray:[(NSArray*)thing ek_flattenedArray]];
-        } else {
+            [result addObjectsFromArray:[(NSArray*)thing ek_flattenedCompactedArray]];
+        } else if (![thing isEqual:[NSNull null]]) {
             [result addObject:thing];
         }
     }

--- a/EasyMappingExample/Classes/Models/ManagedPerson.h
+++ b/EasyMappingExample/Classes/Models/ManagedPerson.h
@@ -19,8 +19,8 @@
 @property (nonatomic, retain) NSString * email;
 @property (nonatomic, retain) ManagedCar *car;
 
-@property (nonatomic, strong) ManagedPerson * spouse;
-@property (nonatomic, strong) NSSet *relative;
+@property (nonatomic, strong) NSSet * children;
+@property (nonatomic, strong) ManagedPerson *relative;
 
 @property (nonatomic, retain) NSSet *phones;
 @property (nonatomic, retain) NSString * gender;

--- a/EasyMappingExample/Classes/Models/ManagedPerson.h
+++ b/EasyMappingExample/Classes/Models/ManagedPerson.h
@@ -18,6 +18,7 @@
 @property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) NSString * email;
 @property (nonatomic, retain) ManagedCar *car;
+@property (nonatomic, strong) ManagedPerson * relative;
 @property (nonatomic, retain) NSSet *phones;
 @property (nonatomic, retain) NSString * gender;
 @end

--- a/EasyMappingExample/Classes/Models/ManagedPerson.h
+++ b/EasyMappingExample/Classes/Models/ManagedPerson.h
@@ -18,7 +18,10 @@
 @property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) NSString * email;
 @property (nonatomic, retain) ManagedCar *car;
-@property (nonatomic, strong) ManagedPerson * relative;
+
+@property (nonatomic, strong) ManagedPerson * spouse;
+@property (nonatomic, strong) NSSet *relative;
+
 @property (nonatomic, retain) NSSet *phones;
 @property (nonatomic, retain) NSString * gender;
 @end

--- a/EasyMappingExample/Classes/Models/ManagedPerson.m
+++ b/EasyMappingExample/Classes/Models/ManagedPerson.m
@@ -19,6 +19,7 @@
 @dynamic phones;
 @dynamic gender;
 @dynamic relative;
+@dynamic spouse;
 
 static EKManagedObjectMapping * mapping = nil;
 

--- a/EasyMappingExample/Classes/Models/ManagedPerson.m
+++ b/EasyMappingExample/Classes/Models/ManagedPerson.m
@@ -18,6 +18,7 @@
 @dynamic car;
 @dynamic phones;
 @dynamic gender;
+@dynamic relative;
 
 static EKManagedObjectMapping * mapping = nil;
 

--- a/EasyMappingExample/Classes/Models/ManagedPerson.m
+++ b/EasyMappingExample/Classes/Models/ManagedPerson.m
@@ -19,7 +19,7 @@
 @dynamic phones;
 @dynamic gender;
 @dynamic relative;
-@dynamic spouse;
+@dynamic children;
 
 static EKManagedObjectMapping * mapping = nil;
 

--- a/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
+++ b/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
@@ -102,6 +102,7 @@
         [mapping mapPropertiesFromDictionary:@{ @"id": @"personID" }];
         [mapping mapPropertiesFromArray:@[@"name", @"email", @"gender"]];
         [mapping hasOne:ManagedCar.class forKeyPath:@"car"];
+        [mapping hasOne:ManagedPerson.class forKeyPath:@"spouse"];
         [mapping hasMany:ManagedPerson.class forKeyPath:@"relative"];
         [mapping hasMany:ManagedPhone.class forKeyPath:@"phones"];
         mapping.primaryKey = @"personID";

--- a/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
+++ b/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
@@ -102,6 +102,7 @@
         [mapping mapPropertiesFromDictionary:@{ @"id": @"personID" }];
         [mapping mapPropertiesFromArray:@[@"name", @"email", @"gender"]];
         [mapping hasOne:ManagedCar.class forKeyPath:@"car"];
+        [mapping hasMany:ManagedPerson.class forKeyPath:@"relative"];
         [mapping hasMany:ManagedPhone.class forKeyPath:@"phones"];
         mapping.primaryKey = @"personID";
     }];

--- a/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
+++ b/EasyMappingExample/Classes/Providers/ManagedMappingProvider.m
@@ -102,8 +102,8 @@
         [mapping mapPropertiesFromDictionary:@{ @"id": @"personID" }];
         [mapping mapPropertiesFromArray:@[@"name", @"email", @"gender"]];
         [mapping hasOne:ManagedCar.class forKeyPath:@"car"];
-        [mapping hasOne:ManagedPerson.class forKeyPath:@"spouse"];
-        [mapping hasMany:ManagedPerson.class forKeyPath:@"relative"];
+        [mapping hasOne:ManagedPerson.class forKeyPath:@"relative"];
+        [mapping hasMany:ManagedPerson.class forKeyPath:@"children"];
         [mapping hasMany:ManagedPhone.class forKeyPath:@"phones"];
         mapping.primaryKey = @"personID";
     }];

--- a/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
+++ b/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6252" systemVersion="14B25" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14A343f" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="ManagedCar" representedClassName="ManagedCar" syncable="YES">
         <attribute name="carID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
@@ -14,6 +14,7 @@
         <attribute name="personID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <relationship name="car" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedCar" inverseName="person" inverseEntity="ManagedCar" syncable="YES"/>
         <relationship name="phones" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ManagedPhone" inverseName="persons" inverseEntity="ManagedPhone" syncable="YES"/>
+        <relationship name="relative" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="relative" inverseEntity="ManagedPerson" syncable="YES"/>
     </entity>
     <entity name="ManagedPhone" representedClassName="ManagedPhone" syncable="YES">
         <attribute name="ddd" optional="YES" attributeType="String" syncable="YES"/>
@@ -24,7 +25,7 @@
     </entity>
     <elements>
         <element name="ManagedCar" positionX="135" positionY="0" width="128" height="120"/>
-        <element name="ManagedPerson" positionX="-164" positionY="36" width="128" height="133"/>
+        <element name="ManagedPerson" positionX="-164" positionY="36" width="128" height="150"/>
         <element name="ManagedPhone" positionX="-362" positionY="-36" width="128" height="118"/>
     </elements>
 </model>

--- a/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
+++ b/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
@@ -14,7 +14,7 @@
         <attribute name="personID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <relationship name="car" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedCar" inverseName="person" inverseEntity="ManagedCar" syncable="YES"/>
         <relationship name="phones" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ManagedPhone" inverseName="persons" inverseEntity="ManagedPhone" syncable="YES"/>
-        <relationship name="relative" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="relative" inverseEntity="ManagedPerson" syncable="YES"/>
+        <relationship name="relative" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="relative" inverseEntity="ManagedPerson" syncable="YES"/>
         <relationship name="spouse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="spouse" inverseEntity="ManagedPerson" syncable="YES"/>
     </entity>
     <entity name="ManagedPhone" representedClassName="ManagedPhone" syncable="YES">

--- a/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
+++ b/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
@@ -13,9 +13,9 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="personID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <relationship name="car" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedCar" inverseName="person" inverseEntity="ManagedCar" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ManagedPerson" syncable="YES"/>
         <relationship name="phones" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ManagedPhone" inverseName="persons" inverseEntity="ManagedPhone" syncable="YES"/>
-        <relationship name="relative" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="relative" inverseEntity="ManagedPerson" syncable="YES"/>
-        <relationship name="spouse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="spouse" inverseEntity="ManagedPerson" syncable="YES"/>
+        <relationship name="relative" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="relative" inverseEntity="ManagedPerson" syncable="YES"/>
     </entity>
     <entity name="ManagedPhone" representedClassName="ManagedPhone" syncable="YES">
         <attribute name="ddd" optional="YES" attributeType="String" syncable="YES"/>

--- a/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
+++ b/EasyMappingExample/EasyMappingExample.xcdatamodeld/EasyMappingExample.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14A343f" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14B25" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="ManagedCar" representedClassName="ManagedCar" syncable="YES">
         <attribute name="carID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
@@ -15,6 +15,7 @@
         <relationship name="car" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedCar" inverseName="person" inverseEntity="ManagedCar" syncable="YES"/>
         <relationship name="phones" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ManagedPhone" inverseName="persons" inverseEntity="ManagedPhone" syncable="YES"/>
         <relationship name="relative" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="relative" inverseEntity="ManagedPerson" syncable="YES"/>
+        <relationship name="spouse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ManagedPerson" inverseName="spouse" inverseEntity="ManagedPerson" syncable="YES"/>
     </entity>
     <entity name="ManagedPhone" representedClassName="ManagedPhone" syncable="YES">
         <attribute name="ddd" optional="YES" attributeType="String" syncable="YES"/>
@@ -25,7 +26,7 @@
     </entity>
     <elements>
         <element name="ManagedCar" positionX="135" positionY="0" width="128" height="120"/>
-        <element name="ManagedPerson" positionX="-164" positionY="36" width="128" height="150"/>
+        <element name="ManagedPerson" positionX="-164" positionY="36" width="128" height="165"/>
         <element name="ManagedPhone" positionX="-362" positionY="-36" width="128" height="118"/>
     </elements>
 </model>

--- a/EasyMappingExample/Tests/Specs/EKManagedObjectMappingSpec.m
+++ b/EasyMappingExample/Tests/Specs/EKManagedObjectMappingSpec.m
@@ -354,16 +354,9 @@ describe(@"EKManagedObjectMapping", ^{
         
         specify(^{
             [[mapping.hasOneMappings objectForKey:@"car"] shouldNotBeNil];
+            [[mapping.hasOneMappings objectForKey:@"relative"] shouldNotBeNil];
         });
-        
-        specify(^{
-            [mapping.hasManyMappings shouldNotBeNil];
-        });
-        
-        specify(^{
-            [[mapping.hasManyMappings objectForKey:@"phones"] shouldNotBeNil];
-        });
-        
+       
     });
     
     describe(@"#hasManyMapping:forKey:", ^{
@@ -380,6 +373,7 @@ describe(@"EKManagedObjectMapping", ^{
         
         specify(^{
             [[mapping.hasManyMappings objectForKey:@"phones"] shouldNotBeNil];
+            [[mapping.hasManyMappings objectForKey:@"children"] shouldNotBeNil];
         });
         
     });


### PR DESCRIPTION
This PR should fix #86:

- The method ``ek_flattenedArray`` still keep the ``[NSNull null]`` which can cause problem, renamed it to ``ek_flattenedCompactedArray``, which also remove the NSNull.
- Add checks on hasOne and hasMany mapping, if the array is empty, skip further processing.
