### PR TITLE
serializedObject changed to serializedObjectInContext: for EKManagedObjectModel

### DIFF
--- a/EasyMapping/EKManagedObjectModel.h
+++ b/EasyMapping/EKManagedObjectModel.h
@@ -31,8 +31,10 @@
 /**
  Serialize mapped object back to JSON representation.
  
+ @param context, from which object will be serialized
+ 
  @return NSDictionary representation of current object.
  */
-- (NSDictionary *)serializedObject;
+- (NSDictionary *)serializedObjectInContext:(NSManagedObjectContext *)context;
 
 @end

--- a/EasyMapping/EKManagedObjectModel.m
+++ b/EasyMapping/EKManagedObjectModel.m
@@ -24,10 +24,11 @@
 
 #pragma mark - serialization
 
-- (NSDictionary *)serializedObject
+- (NSDictionary *)serializedObjectInContext:(NSManagedObjectContext *)context
 {
     return [EKSerializer serializeObject:self
-                             withMapping:[self.class objectMapping]];
+                             withMapping:[self.class objectMapping]
+                             fromContext:context];
 }
 
 #pragma mark - EKManagedMappingProtocol


### PR DESCRIPTION
NSManagedContext has been added as an argument to serialization method of EKManagedObjectModel. Otherwise, managedReverseBlock was not invoked while serialization because 
+setValueOnRepresentation:fromObject:object withPropertyMapping: are playing only with reverseBlock.
After applying the fix, 
+(void)setValueOnRepresentation:(NSMutableDictionary *)representation fromManagedObject:(id)object
            withPropertyMapping:(EKPropertyMapping *)propertyMapping inContext:(NSManagedObjectContext *)context
called and triggers managedReverseBlock to invoke if exists.