### PR TITLE
Fixed imports for XCode 7.1 and cocoapods.

### DIFF
--- a/EasyMapping/EasyMapping.h
+++ b/EasyMapping/EasyMapping.h
@@ -21,14 +21,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <EasyMapping/EKMapper.h>
-#import <EasyMapping/EKSerializer.h>
-#import <EasyMapping/EKObjectMapping.h>
-#import <EasyMapping/EKManagedObjectMapper.h>
-#import <EasyMapping/EKManagedObjectMapping.h>
-#import <EasyMapping/EKMappingBlocks.h>
-#import <EasyMapping/EKObjectModel.h>
-#import <EasyMapping/EKManagedObjectModel.h>
-#import <EasyMapping/EKMappingProtocol.h>
-#import <EasyMapping/EKPropertyMapping.h>
-#import <EasyMapping/NSDateFormatter+EasyMappingAdditions.h>
+#import "EKMapper.h"
+#import "EKSerializer.h"
+#import "EKObjectMapping.h"
+#import "EKManagedObjectMapper.h"
+#import "EKManagedObjectMapping.h"
+#import "EKMappingBlocks.h"
+#import "EKObjectModel.h"
+#import "EKManagedObjectModel.h"
+#import "EKMappingProtocol.h"
+#import "EKPropertyMapping.h"
+#import "NSDateFormatter+EasyMappingAdditions.h"


### PR DESCRIPTION
When I am trying to use EasyMapping in a cocoapod private repository with mixed sourcefiles Swift and Obj-c I get the following error: "include of non-modular header inside framework module error", when my import is #import<EasyMapping/EasyMapping.h>.
To fix this error I need to change my import to: @import EasyMapping;
The problem is EasyMapping.h which is using the old version.
This is my fix for the previous issue.

P.S. related discussions: https://github.com/CocoaPods/CocoaPods/issues/4420