### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Thanks to:
 
 ## Requirements
 
-* XCode 6.3 and higher
+* Xcode 6.3 and higher
 * iOS 5 and higher
 * Mac OS X 10.7 and higher
 * ARC


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
